### PR TITLE
Fix #30 : add postframecallback fix to main widget

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,23 @@
 {
     "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#fa0f3e",
+        "activityBar.activeBackground": "#4a0c96",
         "activityBar.activeBorder": "#2fdb05",
-        "activityBar.background": "#fa0f3e",
+        "activityBar.background": "#4a0c96",
         "activityBar.foreground": "#e7e7e7",
         "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#2fdb05",
-        "activityBarBadge.foreground": "#15202b",
-        "sash.hoverBorder": "#fa0f3e",
-        "statusBar.background": "#d2042d",
+        "activityBarBadge.background": "#b1570e",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "sash.hoverBorder": "#4a0c96",
+        "statusBar.background": "#330867",
         "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#fa0f3e",
-        "statusBarItem.remoteBackground": "#d2042d",
+        "statusBarItem.hoverBackground": "#4a0c96",
+        "statusBarItem.remoteBackground": "#330867",
         "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#d2042d",
+        "titleBar.activeBackground": "#330867",
         "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#d2042d99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveBackground": "#33086799",
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "commandCenter.border": "#e7e7e799"
     },
-    "peacock.color": "D2042D"
+    "peacock.color": "#330867"
 }

--- a/lib/cherry_toast.dart
+++ b/lib/cherry_toast.dart
@@ -367,7 +367,17 @@ class _CherryToastState extends State<CherryToast>
         break;
       default:
     }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+
+    /// ! To support Flutter < 3.0.0
+    /// This allows a value of type T or T?
+    /// to be treated as a value of type T?.
+    ///
+    /// We use this so that APIs that have become
+    /// non-nullable can still be used with `!` and `?`
+    /// to support older versions of the API as well.
+    T? ambiguate<T>(T? value) => value;
+
+    ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
       slideController.forward();
     });
   }


### PR DESCRIPTION
**Issue** 
When initializing the main widgt we use addPostFrameCallback on a potential nullable `WidgetBinding.instance` with Flutter versions previous to Flutter 3 this can make a problem

**Fix**
Add `ambiguate` callback to check on the nullable object `WidgetBinding.instance`