### PR TITLE
Fix overlay not getting from navigator context

### DIFF
--- a/lib/cherry_toast.dart
+++ b/lib/cherry_toast.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:cherry_toast/cherry_toast_icon.dart';
 import 'package:cherry_toast/resources/arrays.dart';
 import 'package:cherry_toast/resources/colors.dart';
@@ -322,7 +323,13 @@ class CherryToast extends StatefulWidget {
 
   void show(BuildContext context) {
     overlayEntry = _overlayEntryBuilder();
-    Overlay.maybeOf(context)?.insert(overlayEntry!);
+    final overlay = Overlay.maybeOf(context);
+
+    if (overlay != null) {
+      overlay.insert(overlayEntry!);
+    } else {
+      Navigator.of(context).overlay?.insert(overlayEntry!);
+    }
   }
 
   void closeOverlay() {
@@ -646,7 +653,7 @@ class _CherryToastState extends State<CherryToast>
                       const SizedBox(
                         height: 5,
                       ),
-                      widget.description!
+                      widget.description!,
                     ],
                   ),
             widget.action != null
@@ -660,10 +667,10 @@ class _CherryToastState extends State<CherryToast>
                           widget.actionHandler?.call();
                         },
                         child: widget.action,
-                      )
+                      ),
                     ],
                   )
-                : Container()
+                : Container(),
           ],
         ),
       ),


### PR DESCRIPTION
`Overlay.maybeOf(context)` throws null when using the navigator context from main app. To fix this issue we get the context from Navigator's overlay if the previous code reports null.