### PR TITLE
Add toast position to alignment

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -114,6 +114,27 @@ class ExampleApp extends StatelessWidget {
           SizedBox(
             width: 300,
             child: ElevatedButton(
+              child: Text('🍒 Center Cherry Toast'),
+              onPressed: () {
+                CherryToast(
+                  icon: Icons.android,
+                  themeColor: Colors.green,
+                  title: Text(''),
+                  displayTitle: false,
+                  description: Text('A center cherry toast example'),
+                  toastPosition: Position.center,
+                  animationDuration: Duration(milliseconds: 1000),
+                  autoDismiss: true,
+                ).show(context);
+              },
+            ),
+          ),
+          SizedBox(
+            height: 10,
+          ),
+          SizedBox(
+            width: 300,
+            child: ElevatedButton(
               child: Text('🍒 Warning Cherry Toast'),
               onPressed: () {
                 CherryToast.warning(

--- a/lib/cherry_toast.dart
+++ b/lib/cherry_toast.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:cherry_toast/cherry_toast_icon.dart';
 import 'package:cherry_toast/resources/arrays.dart';
 import 'package:cherry_toast/resources/colors.dart';
+import 'package:cherry_toast/resources/extensions.dart';
 import 'package:flutter/material.dart';
 
 // ignore: must_be_immutable
@@ -332,7 +333,7 @@ class CherryToast extends StatefulWidget {
           child: AlertDialog(
             backgroundColor: Colors.transparent,
             elevation: 0,
-            alignment: Alignment.topLeft,
+            alignment: toastPosition.alignment,
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             content: this,

--- a/lib/resources/arrays.dart
+++ b/lib/resources/arrays.dart
@@ -8,6 +8,7 @@ enum CherryType {
 
 enum Position {
   top,
+  center,
   bottom,
 }
 

--- a/lib/resources/extensions.dart
+++ b/lib/resources/extensions.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'arrays.dart';
+
+extension PositionExtension on Position {
+  AlignmentGeometry get alignment {
+    switch (this) {
+      case Position.center:
+        return Alignment.center;
+      case Position.top:
+        return Alignment.topCenter;
+      case Position.bottom:
+        return Alignment.bottomCenter;
+    }
+  }
+}


### PR DESCRIPTION
**Description**

Added toast position center and added extension to transform enum position to alignment to support toast positions.

This PR can solve this open [issue](https://github.com/koukibadr/Cherry-Toast/issues/62) ✅


**Changes**

| Before | After |
|---|---|
|![toast_position_no_working](https://github.com/koukibadr/Cherry-Toast/assets/11259032/d5a57a14-7a76-4376-bc86-3e446796820d)|![toast_position_working](https://github.com/koukibadr/Cherry-Toast/assets/11259032/2a7931e6-18b7-4433-bde9-99fc1d9f08cf)|


